### PR TITLE
Closing/Flushing DataOutputStream before calling toByteArray on the underlying ByteArrayOutputStream

### DIFF
--- a/src/main/java/net/sf/ntru/encrypt/EncryptionParameters.java
+++ b/src/main/java/net/sf/ntru/encrypt/EncryptionParameters.java
@@ -252,6 +252,7 @@ public class EncryptionParameters implements Cloneable {
         dos.writeBoolean(fastFp);
         dos.write(polyType.ordinal());
         dos.writeUTF(hashAlg);
+        dos.flush();
     }
 
     

--- a/src/main/java/net/sf/ntru/sign/SignatureParameters.java
+++ b/src/main/java/net/sf/ntru/sign/SignatureParameters.java
@@ -213,6 +213,7 @@ public class SignatureParameters implements Cloneable {
         dos.write(keyGenAlg.ordinal());
         dos.writeUTF(hashAlg);
         dos.write(polyType.ordinal());
+        dos.flush();
     }
 
     @Override

--- a/src/main/java/net/sf/ntru/sign/SignaturePrivateKey.java
+++ b/src/main/java/net/sf/ntru/sign/SignaturePrivateKey.java
@@ -147,6 +147,7 @@ public class SignaturePrivateKey {
             for (int i=0; i<numBases; i++)
                 // all bases except for the first one contain a public key
                 bases.get(i).encode(os, i!=0);
+            dataStream.close();
         } catch (IOException e) {
             throw new NtruException(e);
         }

--- a/src/main/java/net/sf/ntru/sign/SignaturePublicKey.java
+++ b/src/main/java/net/sf/ntru/sign/SignaturePublicKey.java
@@ -92,6 +92,7 @@ public class SignaturePublicKey {
             dataStream.writeShort(h.coeffs.length);
             dataStream.writeShort(q);
             dataStream.write(h.toBinary(q));
+            dataStream.close();
         } catch (IOException e) {
             throw new NtruException(e);
         }


### PR DESCRIPTION
When a DataOutputStream instance wraps an underlying ByteArrayOutputStream instance,
it is recommended to flush or close the DataOutputStream before invoking the underlying instances's toByteArray().
Although in these cases this is not strictly necessary because the
DataOutputStream's close and flush method has no effects. However, it is a good practice to call
flush/close explicitly as mentioned for example [here](http://stackoverflow.com/questions/2984538/how-to-use-bytearrayoutputstream-and-dataoutputstream-simultaneously-java).
This pull request adds close and flush methods at appropriate places.