### PR TITLE
Improvements for HTML5/XHTML specifications.

### DIFF
--- a/src/main/java/net/sf/ntru/arith/package.html
+++ b/src/main/java/net/sf/ntru/arith/package.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
 <html>
 <head>
-<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
 </head>
 <body>
   Contains code for performing arithmetic and higher arithmetic operations

--- a/src/main/java/net/sf/ntru/demo/package.html
+++ b/src/main/java/net/sf/ntru/demo/package.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
 <html>
 <head>
-<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
 </head>
 <body>
   Contains sample and benchmark programs

--- a/src/main/java/net/sf/ntru/encrypt/package.html
+++ b/src/main/java/net/sf/ntru/encrypt/package.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
 <html>
 <head>
-<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
 </head>
 <body>
   Contains classes specific to NTRUEncrypt

--- a/src/main/java/net/sf/ntru/exception/package.html
+++ b/src/main/java/net/sf/ntru/exception/package.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
 <html>
 <head>
-<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
 </head>
 <body>
   Contains NtruException

--- a/src/main/java/net/sf/ntru/polynomial/package.html
+++ b/src/main/java/net/sf/ntru/polynomial/package.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
 <html>
 <head>
-<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
 </head>
 <body>
   Provides classes for performing polynomial arithmetic

--- a/src/main/java/net/sf/ntru/sign/package.html
+++ b/src/main/java/net/sf/ntru/sign/package.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
 <html>
 <head>
-<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
 </head>
 <body>
   Contains classes specific to NTRUSign

--- a/src/main/java/net/sf/ntru/util/package.html
+++ b/src/main/java/net/sf/ntru/util/package.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
 <html>
 <head>
-<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
 </head>
 <body>
   Contains utility classes not directly related to cryptography or math


### PR DESCRIPTION
**Introduction:**
In accordance with the w3 HTML5 specification for HTML code: void tags (see reference) should be marked as self-closing. During a scan of repositories containing HTML files, we found code in your repository that could use this improvement.

Even though the self-closing specification is not a strict requirement by web-browsers, and they will happily parse the tags anyhow - that is not an excuse for not writing specification valid code. And given the spirit of the open-source community, I will be more than happy to push these improvements to you. The changes in this Pull-Request will not break your HTML code.

**References:**
https://www.w3.org/TR/html5/syntax.html#void-elements